### PR TITLE
ci: pin npm major in release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -73,7 +73,9 @@ jobs:
           registry-url: "https://registry.npmjs.org"
 
       - name: Update npm
-        run: npm install -g npm@latest
+        # npm@12 requires Node >=22.22.2, newer than the pinned NODE_VERSION.
+        # Pin the npm major so `latest` drift cannot break releases.
+        run: npm install -g npm@11
 
       - name: Setup pnpm
         uses: pnpm/action-setup@v4


### PR DESCRIPTION
## Problem

The Release workflow failed on the `@nylas/react` 3.2.13 release ([run 29867901325](https://github.com/nylas/javascript/actions/runs/29867901325)):

```
npm error engine Not compatible with your version of node/npm: npm@12.0.1
npm error notsup Required: {"node":"^22.22.2 || ^24.15.0 || >=26.0.0"}
npm error notsup Actual:   {"npm":"10.9.0","node":"v22.12.0"}
```

`npm install -g npm@latest` now resolves to npm@12, which requires a newer Node than the pinned `NODE_VERSION` (22.12.0). Every release fails until this is fixed — deterministic, not flaky.

## Fix

Pin the npm major (`npm@11`) so `latest` drift can't break releases. Alternative considered: bumping the `NODE_VERSION` repo variable — that also works but changes the build/publish runtime for all jobs and only defers the next `latest` breakage.

## Context

This is blocking the release of `@nylas/react@3.2.13` (#85 — web-elements 2.5.15 with the HeliosX Scheduler Editor availability fixes, nylas/nylas#957 + #958). Once merged, the Release workflow needs a re-run on main to resume the changesets flow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)